### PR TITLE
Edit db preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,10 @@ In your terminal, clone the project:
 
 ```
 $ git clone git@github.com:applegrain/creact-starter.git
-$ rake db:{create,migrate,seed}
+$ rake db:setup
 ```
 
-If you are having troubles with the above commands and get something like `NoMethodError for details=` run the following:
-
-```
-$ rake db:{drop,setup}
-```
-
-`rake db:setup` will run `schema:load` to do the migrations instead of manually migrating them. If we just run regular migrations, it's as if the migrations hasn't completed before we start using them in our seed file. If anyone knows why, PR's accepted!
+If you were instead to run `$ rake db:{create,migrate,seed}` you might have trouble and get something like `NoMethodError for details=`. This is because when we manually run the `migrate` command, Rails doesn't know that it needs to reset column information on what was just migrated to account for potentially new columns, so it hiccups trying to call methods on those columns. Conversely, the `setup` command includes a step for resetting columns, so we're in the clear to then call methods.
 
 run tests with:
 


### PR DESCRIPTION
Update README to use `rake db:setup` to prepare database and seed file

Add note about why this is the preferred method and why the user might experience errors if attempting to manually run create, migrate, and seed commands
