### PR TITLE
Rename callback function at the end of Part 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,12 +921,12 @@ handleDelete(id) {
     url: `/api/v1/skills/${id}`,
     type: 'DELETE',
     success: () => {
-      this.removeIdeaFromDOM(id);
+      this.removeSkillFromDOM(id);
     }
   });
 },
 
-removeIdeaFromDOM(id) {
+removeSkillFromDOM(id) {
   var newSkills = this.state.skills.filter((skill) => {
     return skill.id != id;
   });


### PR DESCRIPTION
Rename `removeIdeaFromDOM` to `removeSkillFromDOM` to match the rest of the tutorial.

I'm sure it can be hard to keep track 'ideas' vs 'skills' when you have to flip back and forth between SkillInventory and IdeaBox tutorials! :)
