### PR TITLE
Make the updating chain consistent in Part 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,7 +1214,7 @@ This component is just passing it up to its parent.
 **app/assets/javascripts/components/_all_skills.js.jsx**
 ```
 onUpdate(skill) {
-  this.props.onUpdate(skill);
+  this.props.handleUpdate(skill);
 },
 
 render() {
@@ -1247,7 +1247,7 @@ render() {
       <NewSkill handleSubmit={this.handleSubmit} />
       <AllSkills skills={this.state.skills}
                  handleDelete={this.handleDelete}
-                 onUpdate={this.handleUpdate} />
+                 handleUpdate={this.handleUpdate} />
     </div>
   )
 }


### PR DESCRIPTION
It seems like the pattern of `handleUpdate` vs. `onUpdate` gets thrown off in the AllSkills component.

As I understand it, we establish a pattern where:
- the child components have an `onUpdate` method that calls a `handleUpdate` method passed down in the props
- the parent at the top of the chain passes its `handleUpdate` method (where the actual handling of the skill is done) down as `handleUpdate` in the props.

Currently, 
- the Body component passes its `handleUpdate` function down as `onUpdate` to the AllSkills component
- the AllSkills component calls `this.props.onUpdate` from its `onUpdate` function

Instead, I propose that:
- the Body component passes its `handleUpdate` function down as `handleUpdate` to the AllSkills component
- the AllSkills component calls `this.props.handleUpdate` from its `onUpdate` function
